### PR TITLE
Fix FAQ answer

### DIFF
--- a/src/tests/mocks/faq.ts
+++ b/src/tests/mocks/faq.ts
@@ -22,6 +22,6 @@ export const MOCK_FAQS: FAQType[] = [
   {
     question: 'Will I get rewarded?',
     answer:
-      ' Participation in the Trailblazers campaign and minting your Faction Badge on mainnet day gives you exclusive rewards.',
+      ' Participation in the Trailblazers campaign and minting your Faction Badge gives you exclusive rewards.',
   },
 ];


### PR DESCRIPTION
The answer to the question "Will I get rewarded?" in the FAQ mocks has been updated to remove the reference to minting the Faction Badge on mainnet day.