### PR TITLE
[TP-588] change daily max

### DIFF
--- a/src/lib/domains/profile/components/ProfileActivity/ActivityHistoryRow.svelte
+++ b/src/lib/domains/profile/components/ProfileActivity/ActivityHistoryRow.svelte
@@ -62,7 +62,7 @@
 
   <!-- Points Cell -->
   <div class={pointsCellClass}>
-    {#if historyEntry?.points === 0}
+    {#if historyEntry?.points === -1}
       <span class={negativeSentimentClass}>{$t('leaderboard.user.dailyMaxReached')}</span>
     {:else}
       <div class={pointsInnerClass}>


### PR DESCRIPTION
This pull request includes a small change to the `ActivityHistoryRow.svelte` file. The change updates the condition for displaying a specific message when the user's points are `-1` instead of `0`.

* [`src/lib/domains/profile/components/ProfileActivity/ActivityHistoryRow.svelte`](diffhunk://#diff-a991516b4d3c30e01a29555a4fa6608d08f62b883b9622d594147c965c010fbeL65-R65): Modified the condition to check if `historyEntry?.points` is `-1` instead of `0` to display the `dailyMaxReached` message.