### PR TITLE
[FE-603] disable claim components

### DIFF
--- a/src/lib/domains/profile/components/ProfileTabs.svelte
+++ b/src/lib/domains/profile/components/ProfileTabs.svelte
@@ -3,6 +3,7 @@
   import { derived } from 'svelte/store';
 
   import { page } from '$app/stores';
+  import { PUBLIC_CLAIMING_ACTIVE } from '$env/static/public';
   import BadgeRecruitment from '$lib/domains/badges/components/BadgeRecruitment.svelte';
   import DevRoom from '$lib/domains/profile/components/DevRoom/DevRoom.svelte';
   import { ProfileNFTs } from '$lib/domains/profile/components/ProfileNFTs';
@@ -44,11 +45,15 @@
             name: 'Badge Recruitment',
             content: BadgeRecruitment,
           },
-          {
-            slug: 'claim',
-            name: 'Claim',
-            content: ProfileRewardClaim,
-          },
+          ...(PUBLIC_CLAIMING_ACTIVE === 'true'
+            ? [
+                {
+                  slug: 'claim',
+                  name: 'Claim',
+                  content: ProfileRewardClaim,
+                },
+              ]
+            : []),
         ]
       : []),
     ...(isDevelopmentEnv

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -62,7 +62,7 @@
     }
   });
 
-  let showRibbon = true;
+  let showRibbon = false;
 </script>
 
 {#if showRibbon}


### PR DESCRIPTION
This pull request includes changes to the `ProfileTabs.svelte` and `+layout.svelte` files to add new functionality and modify existing behavior. The most important changes include adding a new import, conditionally adding a new tab based on an environment variable, and changing the default value of a variable.

### Changes in `ProfileTabs.svelte`:

* Added import for `PUBLIC_CLAIMING_ACTIVE` from `$env/static/public`.
* Conditionally added a "Claim" tab if `PUBLIC_CLAIMING_ACTIVE` is set to 'true'.

### Change in `+layout.svelte`:

* Changed the default value of `showRibbon` from `true` to `false`.