### PR TITLE
[TP-675] hotfix avalon mapping

### DIFF
--- a/src/lib/domains/profile/mappers/eventToActivityMapper.ts
+++ b/src/lib/domains/profile/mappers/eventToActivityMapper.ts
@@ -8,4 +8,5 @@ export const eventToActivityTypeMap: Record<string, ActivityType> = {
   BlockProven: ActivityType.BLOCK_PROVEN,
   Prediction: ActivityType.PREDICTION,
   DoraHacksVoting: ActivityType.DORAHACKS_VOTE,
+  AvalonClaim: ActivityType.AVALON_CLAIM,
 };


### PR DESCRIPTION
This pull request includes a small change to the `eventToActivityTypeMap` in the `src/lib/domains/profile/mappers/eventToActivityMapper.ts` file. The change adds a new mapping for `AvalonClaim` to the `ActivityType` enumeration.

* [`src/lib/domains/profile/mappers/eventToActivityMapper.ts`](diffhunk://#diff-7bff4a045fde0ff04bb7f341d3a79897405d7f286bc027267303d0479b0f527aR11): Added `AvalonClaim` mapping to `eventToActivityTypeMap`.