### PR TITLE
fix state sync issues

### DIFF
--- a/src/lib/domains/badges/adapter/BadgeRecruitmentAdapter.ts
+++ b/src/lib/domains/badges/adapter/BadgeRecruitmentAdapter.ts
@@ -7,7 +7,7 @@ import {
   watchContractEvent,
   writeContract,
 } from '@wagmi/core';
-import { type Address, parseSignature, recoverAddress } from 'viem';
+import { type Address, isAddressEqual, parseSignature, recoverAddress } from 'viem';
 
 import {
   badgeRecruitmentAbi,
@@ -410,8 +410,9 @@ export default class BadgeRecruitmentAdapter {
       whaleInfluences: r.whaleInfluences,
       minnowInfluences: r.minnowInfluences,
     }));
+    log('getRecruitmentStatusForUser!', { recruitments }, { address });
 
-    const filtered = recruitments.filter((r) => r.user === address);
+    const filtered = recruitments.filter((r) => isAddressEqual(r.user, address));
     log('getRecruitmentStatusForUser', { recruitments: filtered });
     return filtered;
   }

--- a/src/lib/domains/badges/components/BadgeRecruitment.svelte
+++ b/src/lib/domains/badges/components/BadgeRecruitment.svelte
@@ -116,7 +116,6 @@
     if (!browser || isLoading) return;
     isLoading = true;
     const address = getConnectedAddress();
-    // const address = '0x69Bd1321Bea82fE4D4d022d19F8c28499D1282b3';
     if (!address || address === zeroAddress) return;
     const [cycleIdResult, enabledRecruitmentsResult, recruitmentsOfUser] = await Promise.all([
       badgeRecruitmentService.getRecruitmentCycleId(),

--- a/src/lib/domains/badges/components/modal/InfluenceRecruitmentModal.svelte
+++ b/src/lib/domains/badges/components/modal/InfluenceRecruitmentModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { getContext, onMount } from 'svelte';
   import { t } from 'svelte-i18n';
+  import { zeroAddress } from 'viem';
 
   import { MovementNames, Movements } from '$lib/domains/profile/types/types';
   import { errorToast, successToast } from '$shared/components/NotificationToast';
@@ -12,6 +13,7 @@
   } from '$shared/stores/recruitment';
   import type { TBBadge } from '$shared/types/NFT';
   import { classNames } from '$shared/utils/classNames';
+  import getConnectedAddress from '$shared/utils/getConnectedAddress';
 
   import badgeRecruitmentService from '../../services/BadgeRecruitmentServiceInstance';
   import FancyButton from '../FancyButton.svelte';
@@ -73,7 +75,9 @@
     }
   }
 
-  $: influenceRecruitmentModal && $account?.address && badgeRecruitmentService.getUserRecruitments($account.address);
+  $: influenceRecruitmentModal &&
+    getConnectedAddress() !== zeroAddress &&
+    badgeRecruitmentService.getUserRecruitments(getConnectedAddress());
 
   let maxInfluences = 0;
 

--- a/src/lib/domains/profile/components/ProfileModals.svelte
+++ b/src/lib/domains/profile/components/ProfileModals.svelte
@@ -2,7 +2,6 @@
   import EndRecruitmentModal from '$lib/domains/badges/components/modal/EndRecruitmentModal.svelte';
   import InfluenceRecruitmentModal from '$lib/domains/badges/components/modal/InfluenceRecruitmentModal.svelte';
   import StartRecruitmentModal from '$lib/domains/badges/components/modal/StartRecruitmentModal.svelte';
-  import UpdateStatusProvider from '$lib/domains/badges/components/UpdateStatusProvider.svelte';
   import { MintDisclaimerModal } from '$lib/shared/components';
 
   import ProfilePictureModal from './ProfilePicture/ProfilePictureModal.svelte';
@@ -12,9 +11,7 @@
 <ProfilePictureModal />
 <MintDisclaimerModal />
 
-<UpdateStatusProvider>
-  <StartRecruitmentModal />
-  <EndRecruitmentModal />
-  <InfluenceRecruitmentModal />
-</UpdateStatusProvider>
+<StartRecruitmentModal />
+<EndRecruitmentModal />
+<InfluenceRecruitmentModal />
 <ClaimModal />

--- a/src/lib/domains/profile/components/ProfileNFTs/Taikoons/UserNFTItem.svelte
+++ b/src/lib/domains/profile/components/ProfileNFTs/Taikoons/UserNFTItem.svelte
@@ -66,14 +66,10 @@
     <img src={prefixIpfsGateway(image)} alt={`NFT #${token.tokenId}`} class={imageClasses} />
   </div>
 
-  <!-- <div class={bubbleWrapperClasses}>
-    <MultiplierBadge {token} />
-  </div> -->
-
   {#if locked}
     <div class={lockedOverlayClasses}>
       <Icon type="lock" size={80} />
-      <span class="text-sm hidden lg:block">Locked for current season</span>
+      <span class="text-sm hidden lg:block">Max multiplier reached</span>
     </div>
   {/if}
 </div>

--- a/src/routes/profile/[address]/+page.svelte
+++ b/src/routes/profile/[address]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
+  import UpdateStatusProvider from '$lib/domains/badges/components/UpdateStatusProvider.svelte';
   import { Profile } from '$lib/domains/profile/components';
   import { Page } from '$shared/components/Page';
-  // import { Profile } from '$shared/components/Profile';
 </script>
 
 <svelte:head>
@@ -9,5 +9,7 @@
 </svelte:head>
 
 <Page>
-  <Profile />
+  <UpdateStatusProvider>
+    <Profile />
+  </UpdateStatusProvider>
 </Page>


### PR DESCRIPTION
This pull request includes several changes to the `BadgeRecruitmentAdapter` and related components to improve address handling, streamline status updates, and fix some UI elements. The most important changes are grouped by theme below:

### Address Handling Improvements:
* Added `isAddressEqual` utility for address comparison in `BadgeRecruitmentAdapter.ts` and updated the `filter` method to use it. [[1]](diffhunk://#diff-e1a68e9a80cb7987a642a62e26cabb8bb9433ffb768897fcc7a194d6a9187ea1L10-R10) [[2]](diffhunk://#diff-e1a68e9a80cb7987a642a62e26cabb8bb9433ffb768897fcc7a194d6a9187ea1R413-R415)

### Status Update Simplification:
* Removed redundant status update logic and replaced it with context-based updates in `RecruitingStatus.svelte`. [[1]](diffhunk://#diff-60e084233dbb44cd56ba615359805d264ba4e392df53aa3f63e8950e55bc88faL2-L60) [[2]](diffhunk://#diff-60e084233dbb44cd56ba615359805d264ba4e392df53aa3f63e8950e55bc88faL76-L77) [[3]](diffhunk://#diff-60e084233dbb44cd56ba615359805d264ba4e392df53aa3f63e8950e55bc88faL93-L94) [[4]](diffhunk://#diff-60e084233dbb44cd56ba615359805d264ba4e392df53aa3f63e8950e55bc88faL107-R72) [[5]](diffhunk://#diff-60e084233dbb44cd56ba615359805d264ba4e392df53aa3f63e8950e55bc88faR87-R90)
* Ensured status updates are triggered on mount in `RecruitingStatus.svelte`.

### UI and Component Enhancements:
* Updated `InfluenceRecruitmentModal.svelte` to use `getConnectedAddress` and handle zero address cases. [[1]](diffhunk://#diff-c5fb3ac33fbc9364e02ee6dc15d6321ddbcd9671b63b68748a548afc456b337dR4) [[2]](diffhunk://#diff-c5fb3ac33fbc9364e02ee6dc15d6321ddbcd9671b63b68748a548afc456b337dR16) [[3]](diffhunk://#diff-c5fb3ac33fbc9364e02ee6dc15d6321ddbcd9671b63b68748a548afc456b337dL76-R80)
* Removed unused `UpdateStatusProvider` in `ProfileModals.svelte` and added it to `profile/[address]/+page.svelte` instead. [[1]](diffhunk://#diff-df5cdc09e15538159a9a0a53681e5c2e90bdfa1dca6023128bc069def8a18cf0L5) [[2]](diffhunk://#diff-df5cdc09e15538159a9a0a53681e5c2e90bdfa1dca6023128bc069def8a18cf0L15-L19) [src/routes/profile/[address]/+page.svelteR2-R14](diffhunk://#diff-eeda956c71da5d12ac3353c11191d9bd594406f8ee49b2c78372af837e2379eeR2-R14))

### Miscellaneous Fixes:
* Corrected the locked message in `UserNFTItem.svelte` to "Max multiplier reached".
* Cleaned up commented-out code and unused imports in various files. [[1]](diffhunk://#diff-2a7aa3408a63087f9a6675eb26418742e7780191bcb9e0ddf02f9f9276c35205L119) [[2]](diffhunk://#diff-c5fb3ac33fbc9364e02ee6dc15d6321ddbcd9671b63b68748a548afc456b337dR16)