### PR TITLE
fix wrong recruitment status

### DIFF
--- a/src/lib/domains/badges/services/BadgeRecruitmentService.ts
+++ b/src/lib/domains/badges/services/BadgeRecruitmentService.ts
@@ -256,7 +256,7 @@ export default class BadgeRecruitmentService {
       activeRecruitmentStore.set(filtered);
 
       if (filtered.length > 0) {
-        currentRecruitmentStore.set(filtered[filtered.length - 1]);
+        currentRecruitmentStore.set(filtered.find((recruitment) => recruitment.cycle === cycleId) || null);
       }
 
       return filtered;

--- a/src/lib/shared/utils/badges/getRecruitmentStatus.ts
+++ b/src/lib/shared/utils/badges/getRecruitmentStatus.ts
@@ -18,7 +18,10 @@ export const getRecruitmentStatus = (recruitment: ActiveRecruitment, cycle: numb
 
   log('influenceCooldown > now', influenceCooldown > now);
 
-  if ((now > claimCooldown && recruitedBadge && recruitedBadge.tokenId > 0n) || recruitment.badge.tokenId === -1) {
+  if (
+    (claimCooldown > 0 && now > claimCooldown && recruitedBadge && recruitedBadge.tokenId > 0n) ||
+    recruitment.badge.tokenId === -1
+  ) {
     log('Recruitment is completed', recruitment);
     return RecruitmentStatus.COMPLETED;
   }
@@ -46,13 +49,3 @@ export const getRecruitmentStatus = (recruitment: ActiveRecruitment, cycle: numb
   log('Recruitment has not started');
   return RecruitmentStatus.NOT_STARTED;
 };
-
-// ELIGIBLE = 'ELIGIBLE',
-// NOT_STARTED = 'NOT_STARTED',
-// STARTED = 'STARTED',
-// CAN_REFINE = 'CAN_REFINE',
-// CAN_CLAIM = 'CAN_CLAIM',
-// COMPLETED = 'COMPLETED',
-// LOCKED = 'LOCKED',
-1739918040000000;
-1739953090537;


### PR DESCRIPTION
This pull request includes changes to improve the logic for setting recruitment status and cleaning up the codebase. The most important changes include modifying the `BadgeRecruitmentService` to set the current recruitment based on the cycle ID, refining the conditions for determining recruitment status, and removing commented-out code.

Improvements to recruitment logic:

* [`src/lib/domains/badges/services/BadgeRecruitmentService.ts`](diffhunk://#diff-636841dcc997a1cb8e0c2d356ef5dad7ef843804e80b7785fb2b8c646a825d23L259-R259): Modified the `currentRecruitmentStore.set` method to set the current recruitment based on the cycle ID instead of the last item in the filtered list.

* [`src/lib/shared/utils/badges/getRecruitmentStatus.ts`](diffhunk://#diff-10a0dabe6d266573881d678a48596225aa7cab217ebe702ff295ace2e6679b92L21-R24): Refined the conditions for determining if recruitment is completed by adding a check for `claimCooldown` being greater than 0.

Codebase cleanup:

* [`src/lib/shared/utils/badges/getRecruitmentStatus.ts`](diffhunk://#diff-10a0dabe6d266573881d678a48596225aa7cab217ebe702ff295ace2e6679b92L49-L58): Removed commented-out code and unnecessary lines at the end of the file.