### PR TITLE
[TP-762] Add new tx events

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -968,7 +968,9 @@
         "avalon_claim": "Avalon Claim",
         "block_proposed": "Block Proposed",
         "bridged": "Bridged",
+        "compensation": "Compensation",
         "dora_hacks": "DoraHacks Vote",
+        "pfp_bonus": "PFP Bonus",
         "prediction": "Prediction",
         "transaction": "Transaction",
         "transaction_value": "Tx Value"

--- a/src/lib/domains/profile/components/ProfileActivity/ActivityHistoryRow.svelte
+++ b/src/lib/domains/profile/components/ProfileActivity/ActivityHistoryRow.svelte
@@ -60,6 +60,12 @@
     {:else if eventToActivityTypeMap[historyEntry?.event] === ActivityType.AVALON_CLAIM}
       <ActivityIcon type="double-diamond" />
       <span class={eventClasses}>{$t('leaderboard.user.event.avalon_claim')}</span>
+    {:else if eventToActivityTypeMap[historyEntry?.event] === ActivityType.MONK_COMPENSATION}
+      <ActivityIcon type="double-diamond" />
+      <span class={eventClasses}>{$t('leaderboard.user.event.compensation')}</span>
+    {:else if eventToActivityTypeMap[historyEntry?.event] === ActivityType.PFP_BONUS}
+      <ActivityIcon type="cube" />
+      <span class={eventClasses}>{$t('leaderboard.user.event.pfp_bonus')}</span>
     {:else}
       <ActivityIcon type="triple-coin-stacked" />
       <span class={eventClasses}>{$t('leaderboard.user.event.transaction')}</span>

--- a/src/lib/domains/profile/mappers/eventToActivityMapper.ts
+++ b/src/lib/domains/profile/mappers/eventToActivityMapper.ts
@@ -9,4 +9,6 @@ export const eventToActivityTypeMap: Record<string, ActivityType> = {
   Prediction: ActivityType.PREDICTION,
   DoraHacksVoting: ActivityType.DORAHACKS_VOTE,
   AvalonClaim: ActivityType.AVALON_CLAIM,
+  FrozenBonus: ActivityType.MONK_COMPENSATION,
+  PfpRegister: ActivityType.PFP_BONUS,
 };

--- a/src/lib/domains/profile/types/ActivityHistory.ts
+++ b/src/lib/domains/profile/types/ActivityHistory.ts
@@ -33,4 +33,6 @@ export enum ActivityType {
   BLOCK_PROVEN = 'BlockProven',
   DORAHACKS_VOTE = 'DoraHacksVoting',
   AVALON_CLAIM = 'AvalonClaim',
+  MONK_COMPENSATION = 'FrozenBonus',
+  PFP_BONUS = 'PfpRegister',
 }

--- a/src/routes/api/mock-api/s4/user/history/+server.ts
+++ b/src/routes/api/mock-api/s4/user/history/+server.ts
@@ -1,6 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { Address } from 'viem';
 
+import { eventToActivityTypeMap } from '$lib/domains/profile/mappers/eventToActivityMapper';
 import { ActivityType, type UserPointHistory } from '$lib/domains/profile/types/ActivityHistory';
 
 type APIResponse<T> = {
@@ -21,6 +22,22 @@ export function GET({ url }) {
 
   return json({
     items: [
+      {
+        address: address,
+        points: 2000,
+        event: eventToActivityTypeMap['PfpRegister'],
+        date: 1721642099,
+        multiplier: 1,
+        tx_hash: '0x1234567890abcdef',
+      },
+      {
+        address: address,
+        points: 2_125,
+        event: eventToActivityTypeMap['FrozenBonus'],
+        date: 1721642099,
+        multiplier: 1,
+        tx_hash: '0x1234567890abcdef',
+      },
       {
         address: address,
         points: 50_000,


### PR DESCRIPTION
This pull request introduces new activity types and updates the relevant mappings and components to support these additions. The changes ensure that the new activity types are properly recognized and displayed in the user interface.

### New Activity Types and Mappings:

* [`src/i18n/en.json`](diffhunk://#diff-85a7f9f12f8ccede1618ba1ef3c66c7b8cbb6da984cd2ef77af1400672330e31R971-R973): Added new translations for "Compensation" and "PFP Bonus".
* [`src/lib/domains/profile/types/ActivityHistory.ts`](diffhunk://#diff-b5813886aabd58b956d2903a30ccba90b8fb238321e8c079fbc125a8d2529a6dR36-R37): Added `MONK_COMPENSATION` and `PFP_BONUS` to the `ActivityType` enum.
* [`src/lib/domains/profile/mappers/eventToActivityMapper.ts`](diffhunk://#diff-7bff4a045fde0ff04bb7f341d3a79897405d7f286bc027267303d0479b0f527aR12-R13): Mapped `FrozenBonus` and `PfpRegister` to the new activity types in `eventToActivityTypeMap`.

### Component Updates:

* [`src/lib/domains/profile/components/ProfileActivity/ActivityHistoryRow.svelte`](diffhunk://#diff-a991516b4d3c30e01a29555a4fa6608d08f62b883b9622d594147c965c010fbeR63-R68): Added cases for the new activity types to display the corresponding icons and labels.

### Mock API Updates:

* [`src/routes/api/mock-api/s4/user/history/+server.ts`](diffhunk://#diff-029652a5458f0870613a61dd83ba42674c8e08eaa323dae5928798072f649d4aR4): Imported `eventToActivityTypeMap` and added mock data entries for the new activity types in the API response. [[1]](diffhunk://#diff-029652a5458f0870613a61dd83ba42674c8e08eaa323dae5928798072f649d4aR4) [[2]](diffhunk://#diff-029652a5458f0870613a61dd83ba42674c8e08eaa323dae5928798072f649d4aR25-R40)