### PR TITLE
[TP-787] add thrillblazer edition 5

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -815,29 +815,6 @@
         "text": ""
       }
     },
-    "thrillblazer": {
-      "ended": {
-        "description": "",
-        "title": ""
-      },
-      "prize_breakdown": {
-        "fifth": {
-          "amount": ""
-        },
-        "first": {
-          "amount": ""
-        },
-        "fourth": {
-          "amount": ""
-        },
-        "second": {
-          "amount": ""
-        },
-        "third": {
-          "amount": ""
-        }
-      }
-    },
     "thrillblazers": {
       "edition1": {
         "description": "Thrill-Blazer launches Oct 18th. Calling all gaming and SocialFi dApps: Blaze new trails, fuel Taiko's momentum, and seize your chance for legendary rewards!",
@@ -914,7 +891,38 @@
       "edition4": {
         "description": "Blaze new trails, fuel Taiko's momentum, and seize your chance for legendary rewards!",
         "ended": {
-          "description": "Our journey concluded on June 16th, 2025. Congratulations to the winners!",
+          "description": "Our journey concluded on April 18th, 2025. Congratulations to the winners!",
+          "title": "Journey ended"
+        },
+        "prize_breakdown": {
+          "fifth": {
+            "amount": "15k"
+          },
+          "first": {
+            "amount": "45k"
+          },
+          "fourth": {
+            "amount": "20k"
+          },
+          "second": {
+            "amount": "30k"
+          },
+          "seventh": {
+            "amount": "5k"
+          },
+          "sixth": {
+            "amount": "10k"
+          },
+          "third": {
+            "amount": "25k"
+          },
+          "total": "150k TAIKO Tokens"
+        }
+      },
+      "edition5": {
+        "description": "Blaze new trails, fuel Taiko's momentum, and seize your chance for legendary rewards!",
+        "ended": {
+          "description": "Our journey concluded on May 18th, 2025. Congratulations to the winners!",
           "title": "Journey ended"
         },
         "prize_breakdown": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -891,7 +891,7 @@
       "edition4": {
         "description": "Blaze new trails, fuel Taiko's momentum, and seize your chance for legendary rewards!",
         "ended": {
-          "description": "Our journey concluded on April 18th, 2025. Congratulations to the winners!",
+          "description": "Our journey concluded on April 17th, 2025. Congratulations to the winners!",
           "title": "Journey ended"
         },
         "prize_breakdown": {

--- a/src/lib/domains/leaderboard/components/Competition/DappCompetition/Thrillblazer/Header/Header.svelte
+++ b/src/lib/domains/leaderboard/components/Competition/DappCompetition/Thrillblazer/Header/Header.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
-  import { getContext } from 'svelte';
+  import { getContext, onMount } from 'svelte';
   import { t } from 'svelte-i18n';
 
+  import { browser } from '$app/environment';
   import { LastUpdated } from '$lib/domains/leaderboard/components';
   import Search from '$lib/domains/leaderboard/components/Search.svelte';
   import type { DappLeaderboardItem } from '$lib/domains/leaderboard/dto/dapps.dto';
   import { competitionSlug } from '$lib/domains/leaderboard/stores/dappCompetitionStore';
   import type { LoadLeaderboardDataType } from '$lib/domains/leaderboard/types/shared/types';
   import type { PaginationInfo } from '$shared/dto/CommonPageApiResponse';
+  import { activeSeason } from '$shared/stores/activeSeason';
   import { classNames } from '$shared/utils/classNames';
   import { numberToRoman } from '$shared/utils/numberToRoman';
   import { isMobile } from '$shared/utils/responsiveCheck';
@@ -115,9 +117,6 @@
   const lastUpdatedClasses = classNames('mt-[30px]', 'mb-[40px]', 'md:my-[20px]', 'lg:my-[10px]', 'lg:order-1');
 
   const searchClasses = classNames('w-full', 'lg:w-[400px]', 'lg:order-1', 'order-last', 'z-0', 'ml-[3px]');
-
-  $: description = $t(`leaderboard.thrillblazers.edition${edition}.description`);
-  $: edition = parseInt($competitionSlug);
 
   const editionClasses = classNames(
     'uppercase',
@@ -248,6 +247,18 @@
   );
 
   const backgroundClasses = classNames('z-0', 'top-0', 'absolute', 'w-full', 'h-full', 'bg-fit');
+
+  let thrillblazerDetails: Record<number, CompetitionInfo> | null = null;
+
+  $: description = thrillblazerDetails ? thrillblazerDetails[edition]?.description : '';
+  $: edition = parseInt($competitionSlug);
+
+  onMount(async () => {
+    thrillblazerDetails = await getThrillblazerDetails();
+    if (browser && $activeSeason && pageInfo && thrillblazerDetails) {
+      loadLeaderboardData(pageInfo.page);
+    }
+  });
 </script>
 
 <div class={wrapperClasses}>

--- a/src/lib/domains/leaderboard/components/Competition/DappCompetition/Thrillblazer/ThrillblazerLeaderboard.svelte
+++ b/src/lib/domains/leaderboard/components/Competition/DappCompetition/Thrillblazer/ThrillblazerLeaderboard.svelte
@@ -23,7 +23,7 @@
 
   $: reactiveEdition = edition;
 
-  const currentEdition: number = 4;
+  const currentEdition: number = 5;
 
   $: totalItems = pageInfo?.total || 0;
   $: hasEnded = reactiveEdition !== currentEdition;
@@ -70,8 +70,8 @@
       ended={hasEnded}
       qualifyingPositions={thrillblazerDetails[edition].qualifyingPositions}
       endedComponent={CampaignEndedInfoBox}
-      endTitleText={$t(`leaderboard.thrillblazers.${edition}.ended.title`)}
-      endDescriptionText={$t(`leaderboard.thrillblazers.${edition}.ended.description`)}
+      endTitleText={$t(`leaderboard.thrillblazers.edition${edition}.ended.title`)}
+      endDescriptionText={$t(`leaderboard.thrillblazers.edition${edition}.ended.description`)}
       showPagination={true}
       headerComponent={Header}
       scoreComponent={PointScore} />

--- a/src/lib/domains/leaderboard/components/Competition/DappCompetition/Thrillblazer/thrillblazerDetails.ts
+++ b/src/lib/domains/leaderboard/components/Competition/DappCompetition/Thrillblazer/thrillblazerDetails.ts
@@ -12,7 +12,7 @@ const thrillblazerDetailsPromise = (async () => {
   thrillblazerDetails = {
     1: {
       title: '',
-      description: '',
+      description: get(t)('leaderboard.thrillblazers.edition1.description'),
       prizeTitle: get(t)('leaderboard.gaming.prize.1'),
       prizeSubtitle: '',
       prizes: [
@@ -41,7 +41,7 @@ const thrillblazerDetailsPromise = (async () => {
     },
     2: {
       title: '',
-      description: '',
+      description: get(t)('leaderboard.thrillblazers.edition2.description'),
       prizeTitle: get(t)('leaderboard.gaming.prize.1'),
       prizeSubtitle: '',
       prizes: [
@@ -66,7 +66,7 @@ const thrillblazerDetailsPromise = (async () => {
     },
     3: {
       title: '',
-      description: '',
+      description: get(t)('leaderboard.thrillblazers.edition3.description'),
       prizeTitle: get(t)('leaderboard.gaming.prize.1'),
       prizeSubtitle: '',
       prizes: [
@@ -95,7 +95,7 @@ const thrillblazerDetailsPromise = (async () => {
     },
     4: {
       title: '',
-      description: '',
+      description: get(t)('leaderboard.thrillblazers.edition4.description'),
       prizeTitle: get(t)('leaderboard.gaming.prize.1'),
       prizeSubtitle: '',
       prizes: [
@@ -126,6 +126,43 @@ const thrillblazerDetailsPromise = (async () => {
         {
           image: '/thrillblazers/prize/default.svg',
           amount: get(t)('leaderboard.thrillblazers.edition4.prize_breakdown.seventh.amount'),
+        },
+      ],
+      qualifyingPositions: 7,
+    },
+    5: {
+      title: '',
+      description: get(t)('leaderboard.thrillblazers.edition5.description'),
+      prizeTitle: get(t)('leaderboard.gaming.prize.1'),
+      prizeSubtitle: '',
+      prizes: [
+        {
+          image: '/thrillblazers/prize/first.svg',
+          amount: get(t)('leaderboard.thrillblazers.edition5.prize_breakdown.first.amount'),
+        },
+        {
+          image: '/thrillblazers/prize/second.svg',
+          amount: get(t)('leaderboard.thrillblazers.edition5.prize_breakdown.second.amount'),
+        },
+        {
+          image: '/thrillblazers/prize/third.svg',
+          amount: get(t)('leaderboard.thrillblazers.edition5.prize_breakdown.third.amount'),
+        },
+        {
+          image: '/thrillblazers/prize/default.svg',
+          amount: get(t)('leaderboard.thrillblazers.edition5.prize_breakdown.fourth.amount'),
+        },
+        {
+          image: '/thrillblazers/prize/default.svg',
+          amount: get(t)('leaderboard.thrillblazers.edition5.prize_breakdown.fifth.amount'),
+        },
+        {
+          image: '/thrillblazers/prize/default.svg',
+          amount: get(t)('leaderboard.thrillblazers.edition5.prize_breakdown.sixth.amount'),
+        },
+        {
+          image: '/thrillblazers/prize/default.svg',
+          amount: get(t)('leaderboard.thrillblazers.edition5.prize_breakdown.seventh.amount'),
         },
       ],
       qualifyingPositions: 7,

--- a/src/lib/domains/leaderboard/services/server/LeaderboardServiceInstances.server.ts
+++ b/src/lib/domains/leaderboard/services/server/LeaderboardServiceInstances.server.ts
@@ -6,6 +6,8 @@ export const thrillblazerInstances: Record<number, DappCompetition> = {
   2: new DappCompetition('thrillblazer', 'thrillblazer', 'Thrillblazers Edition 2', 2),
   3: new DappCompetition('thrillblazer', 'thrillblazer', 'Thrillblazers Edition 3', 3),
   4: new DappCompetition('thrillblazer', 'thrillblazer', 'Thrillblazers Edition 4', 4),
+  5: new DappCompetition('thrillblazer', 'thrillblazer', 'Thrillblazers Edition 5', 5),
+  6: new DappCompetition('thrillblazer', 'thrillblazer', 'Thrillblazers Edition 6', 6),
 };
 
 export const chillblazerServiceInstances: Record<number, DappCompetition> = {

--- a/src/lib/domains/leaderboard/utils/mapEditionToSeason.ts
+++ b/src/lib/domains/leaderboard/utils/mapEditionToSeason.ts
@@ -3,6 +3,9 @@ export const thrillblazerEditionSeasonMapping: Record<number, number> = {
   2: 3, // Edition 2 uses Season 3
   3: 3, // Edition 3 uses Season 3
   4: 4, // Edition 4 uses Season 4
+  5: 4, // Edition 5 uses Season 4
+  6: 4, // Edition 6 uses Season 4
+  7: 5, // Edition 7 uses Season 5
 };
 
 export const chillblazerEditionSeasonMapping: Record<number, number> = {

--- a/src/lib/shared/routes/routes.ts
+++ b/src/lib/shared/routes/routes.ts
@@ -27,6 +27,7 @@ export const routes: NavigationItem[] = [
     name: 'Journeys',
     flamboyant: true,
     children: [
+      { name: 'Thrillblazers V', route: '/journeys/thrillblazers/5', icon: 'nav-cross' },
       { name: 'Thrillblazers IV', route: '/journeys/thrillblazers/4', icon: 'nav-cross' },
       { name: 'Liquidity Royale', route: '/journeys/liquidity/3', icon: 'nav-liquidity' },
       { name: 'Badges', route: '/badge', icon: 'badge-migration' },


### PR DESCRIPTION
This pull request introduces updates to the "Thrillblazers" competition, including the addition of new editions, dynamic handling of competition data, and improvements to the internationalization (i18n) structure. Key changes include adding support for editions 5 and 6, refactoring how competition details are managed, and updating prize breakdowns and descriptions.

### Updates to Thrillblazers Competition:

* Added support for editions 5 and 6, including their descriptions, prize breakdowns, and qualifying positions in `thrillblazerDetails.ts` and `LeaderboardServiceInstances.server.ts`. [[1]](diffhunk://#diff-f3d88b781c2df3d533f86534be219882e08f7689db9855fd9591b58c347febbbR133-R169) [[2]](diffhunk://#diff-6d2dcfe800ee69f1c95b430149fa47c09a47509e31f1f35b3e7c2b3dce14c9dfR9-R10)
* Updated the `thrillblazerEditionSeasonMapping` to map editions 5, 6, and 7 to their respective seasons.
* Included a navigation route for "Thrillblazers V" in the routes configuration.

### Refactoring and Dynamic Data Handling:

* Refactored `Header.svelte` to dynamically load `thrillblazerDetails` using `onMount`, improving flexibility for handling competition data.
* Adjusted the reactive properties in `ThrillblazerLeaderboard.svelte` to use dynamic edition-based data.

### Internationalization (i18n) Enhancements:

* Updated `en.json` to remove unused keys and add new ones for editions 4 and 5, including prize breakdowns and updated descriptions. [[1]](diffhunk://#diff-85a7f9f12f8ccede1618ba1ef3c66c7b8cbb6da984cd2ef77af1400672330e31L818-L840) [[2]](diffhunk://#diff-85a7f9f12f8ccede1618ba1ef3c66c7b8cbb6da984cd2ef77af1400672330e31L917-R925)
* Incorporated i18n keys for descriptions in `thrillblazerDetails.ts` for editions 1 through 5. [[1]](diffhunk://#diff-f3d88b781c2df3d533f86534be219882e08f7689db9855fd9591b58c347febbbL15-R15) [[2]](diffhunk://#diff-f3d88b781c2df3d533f86534be219882e08f7689db9855fd9591b58c347febbbL44-R44) [[3]](diffhunk://#diff-f3d88b781c2df3d533f86534be219882e08f7689db9855fd9591b58c347febbbL69-R69) [[4]](diffhunk://#diff-f3d88b781c2df3d533f86534be219882e08f7689db9855fd9591b58c347febbbL98-R98) [[5]](diffhunk://#diff-f3d88b781c2df3d533f86534be219882e08f7689db9855fd9591b58c347febbbR133-R169)