### PR TITLE
use vite noExternal for reown

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,9 @@ export default defineConfig({
   esbuild: {
     sourcemap: true,
   },
+  ssr: {
+    noExternal: ['@reown/appkit'],
+  },
   plugins: [
     qrcode(),
     sveltekit(), // This plugin gives vite the ability to resolve imports using TypeScript's path mapping.


### PR DESCRIPTION
This pull request updates the Vite configuration to improve server-side rendering (SSR) handling by specifying external dependencies.

### Updates to Vite configuration:

* [`vite.config.ts`](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddR27-R29): Added an `ssr` configuration block to explicitly mark `@reown/appkit` as a non-external dependency for SSR. This ensures that the package is bundled correctly during SSR builds.