### PR TITLE
[hotfix] status display

### DIFF
--- a/src/lib/shared/components/FeaturedCampaigns/cards.ts
+++ b/src/lib/shared/components/FeaturedCampaigns/cards.ts
@@ -17,21 +17,6 @@ export const cards: CampaignCardType[] = [
     },
   },
   {
-    title: 'Liquidity Royale Season 5',
-    text: 'Compete, conquer and earn! 700k TAIKO tokens are up for grabs!',
-    btn: {
-      text: 'Earn now',
-      external: false,
-      destination: '/leaderboard/liquidity/4',
-    },
-    images: {
-      sm: '/campaign/cards/sm/lr-s5.png',
-      md: '/campaign/cards/xl/lr-s5.png',
-      lg: '/campaign/cards/xl/lr-s5.png',
-      xl: '/campaign/cards/xl/lr-s5.png',
-    },
-  },
-  {
     title: 'Blaze new trails with Thrillblazer Edition 8',
     text: 'Blaze new trails, fuel Taiko’s momentum, and seize your chance for legendary rewards.',
     btn: {

--- a/src/lib/shared/utils/formatTaikoStatusPoints.test.ts
+++ b/src/lib/shared/utils/formatTaikoStatusPoints.test.ts
@@ -1,0 +1,93 @@
+import formatTaikoStatusPoints from './formatTaikoStatusPoints';
+
+describe('formatTaikoStatusPoints', () => {
+  it('should format small numbers without commas', () => {
+    expect(formatTaikoStatusPoints(0)).toBe('0');
+    expect(formatTaikoStatusPoints(1)).toBe('1');
+    expect(formatTaikoStatusPoints(42)).toBe('42');
+    expect(formatTaikoStatusPoints(100)).toBe('100');
+    expect(formatTaikoStatusPoints(999)).toBe('999');
+  });
+
+  it('should format thousands with commas', () => {
+    expect(formatTaikoStatusPoints(1000)).toBe('1,000');
+    expect(formatTaikoStatusPoints(1234)).toBe('1,234');
+    expect(formatTaikoStatusPoints(9999)).toBe('9,999');
+    expect(formatTaikoStatusPoints(12345)).toBe('12,345');
+    expect(formatTaikoStatusPoints(99999)).toBe('99,999');
+  });
+
+  it('should format millions with commas', () => {
+    expect(formatTaikoStatusPoints(1000000)).toBe('1,000,000');
+    expect(formatTaikoStatusPoints(1234567)).toBe('1,234,567');
+    expect(formatTaikoStatusPoints(9876543)).toBe('9,876,543');
+    expect(formatTaikoStatusPoints(12345678)).toBe('12,345,678');
+    expect(formatTaikoStatusPoints(999999999)).toBe('999,999,999');
+  });
+
+  it('should format billions and larger numbers with commas', () => {
+    expect(formatTaikoStatusPoints(1000000000)).toBe('1,000,000,000');
+    expect(formatTaikoStatusPoints(1234567890)).toBe('1,234,567,890');
+    expect(formatTaikoStatusPoints(9876543210123)).toBe('9,876,543,210,123');
+    expect(formatTaikoStatusPoints(123456789012345)).toBe('123,456,789,012,345');
+  });
+
+  it('should handle very large numbers (JavaScript safe integers)', () => {
+    expect(formatTaikoStatusPoints(Number.MAX_SAFE_INTEGER)).toBe('9,007,199,254,740,991');
+    expect(formatTaikoStatusPoints(9007199254740991)).toBe('9,007,199,254,740,991');
+  });
+
+  it('should handle decimal numbers with proper formatting', () => {
+    expect(formatTaikoStatusPoints(1234.56)).toBe('1,234.56');
+    expect(formatTaikoStatusPoints(1000000.78)).toBe('1,000,000.78');
+    expect(formatTaikoStatusPoints(123456.12)).toBe('123,456.12');
+  });
+
+  it('should round to maximum 2 decimal places', () => {
+    expect(formatTaikoStatusPoints(1234567.123)).toBe('1,234,567.12');
+    expect(formatTaikoStatusPoints(999999.999)).toBe('1,000,000');
+    expect(formatTaikoStatusPoints(1000000.126)).toBe('1,000,000.13');
+    expect(formatTaikoStatusPoints(123.456789)).toBe('123.46');
+  });
+
+  it('should handle long decimal numbers by rounding to 2 places', () => {
+    expect(formatTaikoStatusPoints(1234567.123456789)).toBe('1,234,567.12');
+    expect(formatTaikoStatusPoints(999999.999999999)).toBe('1,000,000');
+    expect(formatTaikoStatusPoints(1000000.123456789)).toBe('1,000,000.12');
+  });
+
+  it('should handle negative numbers', () => {
+    expect(formatTaikoStatusPoints(-1000)).toBe('-1,000');
+    expect(formatTaikoStatusPoints(-1234567)).toBe('-1,234,567');
+    expect(formatTaikoStatusPoints(-999999999)).toBe('-999,999,999');
+    expect(formatTaikoStatusPoints(-1234.567)).toBe('-1,234.57');
+  });
+
+  it('should handle edge cases', () => {
+    expect(formatTaikoStatusPoints(1001)).toBe('1,001');
+    expect(formatTaikoStatusPoints(10001)).toBe('10,001');
+    expect(formatTaikoStatusPoints(100001)).toBe('100,001');
+    expect(formatTaikoStatusPoints(1000001)).toBe('1,000,001');
+  });
+
+  it('should handle scientific notation inputs', () => {
+    expect(formatTaikoStatusPoints(1e6)).toBe('1,000,000');
+    expect(formatTaikoStatusPoints(1.5e6)).toBe('1,500,000');
+    expect(formatTaikoStatusPoints(2.5e9)).toBe('2,500,000,000');
+  });
+
+  it('should handle decimal edge cases', () => {
+    expect(formatTaikoStatusPoints(0.1)).toBe('0.1');
+    expect(formatTaikoStatusPoints(0.12)).toBe('0.12');
+    expect(formatTaikoStatusPoints(0.123)).toBe('0.12');
+    expect(formatTaikoStatusPoints(0.126)).toBe('0.13');
+    expect(formatTaikoStatusPoints(0.999)).toBe('1');
+  });
+
+  it('should handle rounding edge cases', () => {
+    expect(formatTaikoStatusPoints(999.995)).toBe('1,000');
+    expect(formatTaikoStatusPoints(1234.005)).toBe('1,234.01');
+    expect(formatTaikoStatusPoints(5678.994)).toBe('5,678.99');
+    expect(formatTaikoStatusPoints(9999.996)).toBe('10,000');
+  });
+});

--- a/src/lib/shared/utils/formatTaikoStatusPoints.ts
+++ b/src/lib/shared/utils/formatTaikoStatusPoints.ts
@@ -1,5 +1,14 @@
 export default function formatTaikoStatusPoints(points: number): string {
-  const pointsString = points.toString();
-  const formattedPoints = pointsString.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-  return formattedPoints;
+  // Round to 2 decimal places
+  const roundedPoints = Math.round(points * 100) / 100;
+  const pointsString = roundedPoints.toString();
+
+  // Split into integer and decimal parts
+  const [integerPart, decimalPart] = pointsString.split('.');
+
+  // Add commas to integer part
+  const formattedInteger = integerPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+
+  // Return with or without decimal part
+  return decimalPart ? `${formattedInteger}.${decimalPart}` : formattedInteger;
 }


### PR DESCRIPTION

* Removed the "Liquidity Royale Season 5" campaign card from the `FeaturedCampaigns` card list in `src/lib/shared/components/FeaturedCampaigns/cards.ts`. This reflects the end of the campaign.

* Updated the `formatTaikoStatusPoints` function in `src/lib/shared/utils/formatTaikoStatusPoints.ts` to handle rounding to two decimal places
