### PR TITLE
[TP-779] preconf phase 2

### DIFF
--- a/src/lib/domains/preconf/adapter/server/BasedLinerAdapter.server.ts
+++ b/src/lib/domains/preconf/adapter/server/BasedLinerAdapter.server.ts
@@ -35,6 +35,18 @@ export class BasedLinerAdapter {
         throw new TooManyRequestsError('Rate limit exceeded. Please wait before submitting again.');
       }
 
+      // Check if it's a phase prerequisite error
+      if (error instanceof Error && error.message.includes('requires phase PrePreconf')) {
+        throw new Error(
+          'Phase prerequisite not met: You must complete the PrePreconf phase before submitting PostPreconf transactions.',
+        );
+      }
+
+      // Preserve the original error message if available
+      if (error instanceof Error) {
+        throw new Error(`Failed to submit stage: ${error.message}`);
+      }
+
       throw new Error('Failed to submit stage');
     }
   }

--- a/src/lib/domains/preconf/components/BasedLiners/AfterPreconf.svelte
+++ b/src/lib/domains/preconf/components/BasedLiners/AfterPreconf.svelte
@@ -33,15 +33,18 @@
   let cooldownInterval: NodeJS.Timeout | null = null;
 
   $: noAccount = !$account?.isConnected || $account?.address === zeroAddress;
-
-  // Check resubmit status using persistent storage
   $: userAddress = $account?.address || zeroAddress;
-  $: reSubmitEnabled = !ResubmitStorage.isResubmitBlocked(userAddress, PRECONF_EVENT.BASEDLINER);
+
+  // Check resubmit status using persistent storage - now reactive to remainingCooldown changes
+  $: reSubmitEnabled = remainingCooldown <= 0;
 
   // Update remaining cooldown time
   function updateRemainingCooldown() {
     if (userAddress && userAddress !== zeroAddress) {
-      remainingCooldown = ResubmitStorage.getRemainingCooldown(userAddress, PRECONF_EVENT.BASEDLINER);
+      const newCooldown = ResubmitStorage.getRemainingCooldown(userAddress, PRECONF_EVENT.BASEDLINER);
+      if (newCooldown !== remainingCooldown) {
+        remainingCooldown = newCooldown;
+      }
     } else {
       remainingCooldown = 0;
     }
@@ -57,6 +60,7 @@
 
   $: disabled = noAccount || loading || !isPhaseOpen || !reSubmitEnabled;
   export let error: string | null = null;
+  export let onPhaseComplete: () => Promise<void>;
 
   export let diffAfter = 0;
 
@@ -68,7 +72,12 @@
       const response = await BasedLinerService.registerPhase(PRECONF_EVENT.BASEDLINER, PRECONF_CAMPAIGN_PHASE.AFTER);
       log('diffInSeconds', response.diffInSeconds);
 
-      diffAfter = Math.floor(response.diffInSeconds);
+      diffAfter = response.diffInSeconds;
+
+      // Refresh user data to get updated score from backend
+      if (onPhaseComplete) {
+        await onPhaseComplete();
+      }
 
       // Set persistent resubmit block for 1 minute
       if (userAddress && userAddress !== zeroAddress) {
@@ -149,7 +158,7 @@
 
 <div class={wrapperClasses}>
   <h1>With preconfs</h1>
-  <StaticTime seconds={Math.floor(diffAfter)} />
+  <StaticTime seconds={Math.round(diffAfter)} />
   <div class="absolute bottom-0 left-0 w-full flex flex-col items-center">
     <ActionButton
       class="!max-h-[48px] !max-w-[200px]"
@@ -163,7 +172,7 @@
         Connect wallet
       {:else if !isPhaseOpen}
         Not launched yet
-      {:else if !reSubmitEnabled && remainingCooldown > 0}
+      {:else if remainingCooldown > 0}
         Wait {formatRemainingTime(remainingCooldown)}
       {:else}
         Track your time

--- a/src/lib/domains/preconf/components/BasedLiners/BasedLiners.svelte
+++ b/src/lib/domains/preconf/components/BasedLiners/BasedLiners.svelte
@@ -62,6 +62,40 @@
 
   $: isPhase2Open = false;
 
+  // Reactive score calculation when both phases are completed
+  $: if (diffBefore > 0 && diffAfter > 0 && diffAfter < diffBefore) {
+    score = Math.min(Number(((diffBefore / diffAfter) * 10_000).toFixed(2)), 150_000);
+    log('Score calculated from diffs:', { diffBefore, diffAfter, score });
+  }
+
+  // Debug logging for all score updates
+  $: {
+    log('BasedLiners state update:', { diffBefore, diffAfter, score, isPhase2Open });
+  }
+
+  // Function to refresh user data after phase completion
+  async function refreshUserData() {
+    const address = getConnectedAddress();
+    if (address && address !== zeroAddress) {
+      try {
+        const entry = await BasedLinerService.fetchLeaderboardEntry({
+          eventId: PRECONF_EVENT.BASEDLINER,
+          address,
+        });
+
+        log('Refreshed entry after phase completion:', entry);
+
+        if (entry) {
+          diffBefore = entry.phase1 || 0;
+          diffAfter = entry.phase2 || 0;
+          score = Number(entry.diff) || 0;
+        }
+      } catch (error) {
+        console.error('Error refreshing user data:', error);
+      }
+    }
+  }
+
   onMount(async () => {
     // fetch data from backend
     const address = getConnectedAddress();
@@ -70,7 +104,7 @@
     if (entry) {
       diffBefore = entry.phase1 || 0;
       diffAfter = entry.phase2 || 0;
-      score = entry.diff || 0;
+      score = Number(entry.diff) || 0;
     }
 
     isPhase2Open = await BasedLinerService.isPhaseOpen({
@@ -97,7 +131,7 @@
         if (entry) {
           diffBefore = entry.phase1 || 0;
           diffAfter = entry.phase2 || 0;
-          score = entry.diff || 0;
+          score = Number(entry.diff) || 0;
         } else {
           // Reset values if no entry found for this account
           diffBefore = 0;
@@ -129,9 +163,9 @@
     {/if}
     <div {...dynamicAttrs} class={bodyClasses} id="basedliners-section">
       <div class="f-col lg:f-row {noAccount ? 'blur-md' : ''} w-full lg:h-[250px] h-full">
-        <BeforePreconf bind:error bind:diffBefore />
+        <BeforePreconf bind:error bind:diffBefore onPhaseComplete={refreshUserData} />
         <div class="lg:v-sep h-sep" />
-        <AfterPreconf bind:error bind:diffAfter />
+        <AfterPreconf bind:error bind:diffAfter onPhaseComplete={refreshUserData} />
         <div class="lg:v-sep h-sep" />
         <Score {score} {diffAfter} {diffBefore} {isPhase2Open} />
       </div>

--- a/src/lib/domains/preconf/components/BasedLiners/BeforePreconf.svelte
+++ b/src/lib/domains/preconf/components/BasedLiners/BeforePreconf.svelte
@@ -61,6 +61,7 @@
 
   $: disabled = noAccount || loading || !isPhaseOpen || !reSubmitEnabled;
   export let error: string | null = null;
+  export let onPhaseComplete: () => Promise<void>;
   export let diffBefore: number = 0;
 
   onMount(async () => {
@@ -92,7 +93,12 @@
       const response = await BasedLinerService.registerPhase(PRECONF_EVENT.BASEDLINER, PRECONF_CAMPAIGN_PHASE.BEFORE);
       log('diffInSeconds', response.diffInSeconds);
 
-      diffBefore = Math.floor(response.diffInSeconds);
+      diffBefore = response.diffInSeconds;
+
+      // Refresh user data to get updated score from backend
+      if (onPhaseComplete) {
+        await onPhaseComplete();
+      }
 
       // Set persistent resubmit block for 1 minute
       if (userAddress && userAddress !== zeroAddress) {
@@ -164,7 +170,7 @@
     <!-- <span class="text-sm text-secondary-content">(Before Preconf)</span> -->
   </h1>
 
-  <StaticTime seconds={Math.floor(diffBefore)} />
+  <StaticTime seconds={Math.round(diffBefore)} />
 
   <div class="absolute bottom-0 left-0 w-full flex flex-col items-center">
     {#if error}

--- a/src/lib/domains/preconf/components/BasedLiners/Score.svelte
+++ b/src/lib/domains/preconf/components/BasedLiners/Score.svelte
@@ -37,6 +37,18 @@
 
   $: speedIncreaseTimes = diffBefore && diffAfter ? (diffBefore / diffAfter).toFixed(2) : 0;
 
+  // Track when score first becomes positive to trigger confetti
+  let confettiTrigger = 0;
+  let lastScore = 0;
+
+  $: {
+    // Only increment trigger when score goes from 0/null to positive
+    if (score && score > 0 && lastScore <= 0) {
+      confettiTrigger++;
+    }
+    lastScore = score || 0;
+  }
+
   // const activePhase: PRECONF_CAMPAIGN_PHASE = PRECONF_CAMPAIGN_PHASE.AFTER;
 
   // $: score2 =
@@ -51,10 +63,12 @@
   <h1>Your points</h1>
   <div class={digit}>
     {#if score && isPhase2Open}
-      <Confetti cone x={[-0.5, 0.5]} />
-      {score}
-      <Confetti cone amount={10} x={[-1, -0.4]} y={[0.25, 0.75]} />
-      <Confetti cone amount={10} x={[0.4, 1]} y={[0.25, 0.75]} />
+      {#key confettiTrigger}
+        <Confetti cone x={[-0.5, 0.5]} />
+        {score.toFixed(2)}
+        <Confetti cone amount={10} x={[-1, -0.4]} y={[0.25, 0.75]} />
+        <Confetti cone amount={10} x={[0.4, 1]} y={[0.25, 0.75]} />
+      {/key}
     {:else}
       0
     {/if}
@@ -81,8 +95,10 @@
   </div>
 </div>
 {#if score && score > 0 && isPhase2Open}
-  <div
-    style="position: fixed; z-index: 50; top: -50px; left: 0; height: 100vh; width: 100vw; pointer-events: none; display: flex; justify-content: center; overflow: hidden;">
-    <Confetti x={[-5, 5]} y={[0, 0.1]} delay={[500, 10000]} duration={5000} amount={200} fallDistance="100vh" />
-  </div>
+  {#key confettiTrigger}
+    <div
+      style="position: fixed; z-index: 50; top: -50px; left: 0; height: 100vh; width: 100vw; pointer-events: none; display: flex; justify-content: center; overflow: hidden;">
+      <Confetti x={[-5, 5]} y={[0, 0.1]} delay={[500, 10000]} duration={5000} amount={200} fallDistance="100vh" />
+    </div>
+  {/key}
 {/if}

--- a/src/lib/domains/preconf/service/BasedLinerService.ts
+++ b/src/lib/domains/preconf/service/BasedLinerService.ts
@@ -181,6 +181,6 @@ function mapBasedlinerLeaderboardRow(row: BasedlinerLeaderboard): UnifiedLeaderb
     rank: row.rank,
     icon: '',
     data: [],
-    totalScore: row.diff ? row.diff : 0,
+    totalScore: Number(row.diff) || 0,
   };
 }

--- a/src/lib/domains/preconf/service/server/BasedLinerService.server.ts
+++ b/src/lib/domains/preconf/service/server/BasedLinerService.server.ts
@@ -132,7 +132,14 @@ export class BasedLinerService {
     const txTime = BigInt(timestamp);
     const diff = blockTime - txTime;
 
-    return Number(diff);
+    // Debug logging for negative values
+    if (diff < 0) {
+      log(`Negative diff detected: blockTime=${blockTime}, txTime=${txTime}, diff=${diff}ms`);
+      log(`Block timestamp: ${Number(block.timestamp)} seconds, Tx timestamp: ${timestamp} ms`);
+    }
+
+    // Return absolute value to avoid negative timing results due to clock skew
+    return Number(diff < 0n ? -diff : diff);
   }
 
   /**

--- a/src/lib/shared/services/api/fetchClient.ts
+++ b/src/lib/shared/services/api/fetchClient.ts
@@ -42,7 +42,18 @@ export const fetchFromApi = async <T>(
     });
 
     if (!response.ok) {
-      throw new Error(`API Error: ${response.status} ${response.statusText}`);
+      let errorMessage = `API Error: ${response.status} ${response.statusText}`;
+      try {
+        const errorBody = await response.json();
+        if (errorBody.error) {
+          errorMessage = `API Error: ${response.status} - ${errorBody.error}`;
+        } else if (errorBody.message) {
+          errorMessage = `API Error: ${response.status} - ${errorBody.message}`;
+        }
+      } catch {
+        // If parsing JSON fails, keep the original error message
+      }
+      throw new Error(errorMessage);
     }
 
     return response.json() as Promise<T>;


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the BasedLiner preconf workflow, focusing on more accurate score calculations, improved error handling, and enhanced user experience. The main changes include ensuring score values are always numeric, refreshing user data after phase completion, handling timing edge cases, and providing clearer error feedback. Additionally, the UI now triggers confetti when a user first earns points, and error messages are more descriptive.

**Score calculation and data refresh:**
* Score values (`score`, `diffBefore`, `diffAfter`) are now consistently converted to numbers, preventing type issues and rounding errors. The score calculation is reactive and recalculates when both phases are completed, with a cap at 150,000 points. [[1]](diffhunk://#diff-c9122977e02601d49d3524012be0490b705e35d7a8173185a832e26ebfc24443R65-R98) [[2]](diffhunk://#diff-c9122977e02601d49d3524012be0490b705e35d7a8173185a832e26ebfc24443L73-R107) [[3]](diffhunk://#diff-c9122977e02601d49d3524012be0490b705e35d7a8173185a832e26ebfc24443L100-R134) [[4]](diffhunk://#diff-9bdb4b8dfd05845e47a5c1297d8924041dc8177020df14a87f8951d45a30df37L184-R184)
* After a user completes a phase, the UI now calls `refreshUserData` to fetch the latest leaderboard entry and update the displayed score and timings. This ensures the frontend state matches backend data. [[1]](diffhunk://#diff-c9122977e02601d49d3524012be0490b705e35d7a8173185a832e26ebfc24443L132-R168) [[2]](diffhunk://#diff-62d58d56a791e7d2c22661c61bbe37b8723fb88743d5cd421be387a630d68658R64) [[3]](diffhunk://#diff-62d58d56a791e7d2c22661c61bbe37b8723fb88743d5cd421be387a630d68658L95-R101) [[4]](diffhunk://#diff-cf16ddedd8423582e1003157d02cf8e9a537524bd164c0663a760dbb257b11a2R63) [[5]](diffhunk://#diff-cf16ddedd8423582e1003157d02cf8e9a537524bd164c0663a760dbb257b11a2L71-R80)

**User experience improvements:**
* Confetti animations are triggered only when a user first earns points, using a `confettiTrigger` variable to ensure the effect is shown at the right moment. Score values are displayed with two decimal places for clarity. [[1]](diffhunk://#diff-3afedf568117e01bf0ec9d8c95ce2a9ce22e90376507d1cf5cbf79c4aac9fc53R40-R51) [[2]](diffhunk://#diff-3afedf568117e01bf0ec9d8c95ce2a9ce22e90376507d1cf5cbf79c4aac9fc53R66-R71) [[3]](diffhunk://#diff-3afedf568117e01bf0ec9d8c95ce2a9ce22e90376507d1cf5cbf79c4aac9fc53R98-R103)
* The cooldown and resubmit logic is now more reactive and accurate, updating based on remaining cooldown time instead of persistent storage alone. [[1]](diffhunk://#diff-cf16ddedd8423582e1003157d02cf8e9a537524bd164c0663a760dbb257b11a2L36-R47) [[2]](diffhunk://#diff-cf16ddedd8423582e1003157d02cf8e9a537524bd164c0663a760dbb257b11a2L166-R175)

**Error handling and backend fixes:**
* Error messages for API and phase prerequisite failures are now more descriptive, helping users understand why their actions might fail. [[1]](diffhunk://#diff-99237fda829a2f01478feae6db124dd0366348d6261cb3bee40789c510be42f0R38-R49) [[2]](diffhunk://#diff-4941f7420a476940dc75014798e2e1d34b0a3ad808668216fd57b97525fe2779L45-R56)
* Negative timing results due to clock skew are now logged and converted to absolute values to avoid confusing scores.

**UI consistency:**
* Timing values are now rounded for display, ensuring consistency across the UI. [[1]](diffhunk://#diff-62d58d56a791e7d2c22661c61bbe37b8723fb88743d5cd421be387a630d68658L167-R173) [[2]](diffhunk://#diff-cf16ddedd8423582e1003157d02cf8e9a537524bd164c0663a760dbb257b11a2L152-R161)
