### PR TITLE
[TP-862] add okidori mapping

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1082,6 +1082,7 @@
         "compensation": "Compensation",
         "dora_hacks": "DoraHacks Vote",
         "loopring_deposit": "Loopring Deposit",
+        "okidori": "Okidori",
         "pfp_bonus": "PFP Bonus",
         "prediction": "Prediction",
         "taiko_status_reward": "Taiko Status Reward",

--- a/src/lib/domains/profile/components/ProfileActivity/ActivityHistoryRow.svelte
+++ b/src/lib/domains/profile/components/ProfileActivity/ActivityHistoryRow.svelte
@@ -72,6 +72,9 @@
     {:else if eventToActivityTypeMap[historyEntry?.event] === ActivityType.TAIKO_STATUS_REWARD}
       <ActivityIcon type="double-diamond" />
       <span class={eventClasses}>{$t('leaderboard.user.event.taiko_status_reward')}</span>
+    {:else if eventToActivityTypeMap[historyEntry?.event] === ActivityType.OKIDORI_NFT_SOLD}
+      <ActivityIcon type="cube" />
+      <span class={eventClasses}>{$t('leaderboard.user.event.okidori')}</span>
     {:else}
       <ActivityIcon type="triple-coin-stacked" />
       <span class={eventClasses}>{$t('leaderboard.user.event.transaction')}</span>

--- a/src/lib/domains/profile/mappers/eventToActivityMapper.ts
+++ b/src/lib/domains/profile/mappers/eventToActivityMapper.ts
@@ -13,4 +13,5 @@ export const eventToActivityTypeMap: Record<string, ActivityType> = {
   PfpRegister: ActivityType.PFP_BONUS,
   LoopringDeposit: ActivityType.LOOPRING_DEPOSIT,
   TaikoStatusPoints: ActivityType.TAIKO_STATUS_REWARD,
+  OkidoriNftSold: ActivityType.OKIDORI_NFT_SOLD,
 };

--- a/src/lib/domains/profile/types/ActivityHistory.ts
+++ b/src/lib/domains/profile/types/ActivityHistory.ts
@@ -37,4 +37,5 @@ export enum ActivityType {
   PFP_BONUS = 'PfpRegister',
   LOOPRING_DEPOSIT = 'LoopringDeposit',
   TAIKO_STATUS_REWARD = 'TaikoStatusPoints',
+  OKIDORI_NFT_SOLD = 'OkidoriNftSold',
 }


### PR DESCRIPTION
This pull request adds support for a new activity type, "Okidori NFT Sold", to the user profile activity history feature. The changes ensure that Okidori NFT sale events are properly mapped, displayed, and localized in the UI.

**Activity Type Addition:**

* Added `OKIDORI_NFT_SOLD` to the `ActivityType` enum in `ActivityHistory.ts` to represent Okidori NFT sale events.
* Mapped the `OkidoriNftSold` event string to the new activity type in `eventToActivityTypeMap` within `eventToActivityMapper.ts`.

**UI and Localization Updates:**

* Updated `ProfileActivity/ActivityHistoryRow.svelte` to display a cube icon and localized label for Okidori NFT sale events.
* Added the "Okidori" label to the English translations in `en.json` for proper localization.