### PR TITLE
revert fallback override

### DIFF
--- a/src/lib/domains/preconf/components/BasedLiners/BasedLiners.svelte
+++ b/src/lib/domains/preconf/components/BasedLiners/BasedLiners.svelte
@@ -228,10 +228,7 @@
   </div>
   {#if usedAveragePhase1 && isPhase2Open}
     <div class="w-full mb-[20px]">
-      <Alert type="info">
-        You didn't create a baseline in time, you see the average of other users. Unfortunately this means you can't win
-        the leaderboard anymore. You can still see the speed improvement!
-      </Alert>
+      <Alert type="info">You didn't create a baseline in time, you see the average of other users.</Alert>
     </div>
   {/if}
   <div class="w-full flex">

--- a/src/lib/domains/preconf/components/BasedLiners/BasedLiners.svelte
+++ b/src/lib/domains/preconf/components/BasedLiners/BasedLiners.svelte
@@ -90,7 +90,7 @@
         if (entry) {
           diffBefore = entry.phase1 || 0;
           diffAfter = entry.phase2 || 0;
-          score = Number(entry.diff) || 0;
+          score = Number(entry.score) || Number(entry.diff) || 0;
           // Reset flag if we have actual phase1 data
           if (entry.phase1 && entry.phase1 > 0) {
             usedAveragePhase1 = false;
@@ -124,7 +124,7 @@
     if (entry) {
       diffBefore = entry.phase1 || 0;
       diffAfter = entry.phase2 || 0;
-      score = Number(entry.diff) || 0;
+      score = Number(entry.score) || Number(entry.diff) || 0;
     }
 
     // If no phase1 data, use average phase1 from leaderboard
@@ -164,7 +164,7 @@
         if (entry) {
           diffBefore = entry.phase1 || 0;
           diffAfter = entry.phase2 || 0;
-          score = Number(entry.diff) || 0;
+          score = Number(entry.score) || Number(entry.diff) || 0;
           // Reset flag if we have actual phase1 data
           if (entry.phase1 && entry.phase1 > 0) {
             usedAveragePhase1 = false;

--- a/src/lib/domains/preconf/service/BasedLinerService.test.ts
+++ b/src/lib/domains/preconf/service/BasedLinerService.test.ts
@@ -228,14 +228,14 @@ describe('BasedLinerService', () => {
       {
         address: mockAddress,
         rank: 1,
-        diff: 1000,
+        score: '1000',
         phase1: 500,
         phase2: 600,
       },
       {
         address: '0x9876543210fedcba9876543210fedcba98765432' as Address,
         rank: 2,
-        diff: 2000,
+        score: '2000',
         phase1: 1000,
         phase2: 1200,
       },
@@ -392,6 +392,7 @@ describe('BasedLinerService', () => {
       address: mockAddress,
       rank: 1,
       diff: 1500,
+      score: '1500',
       phase1: 750,
       phase2: 900,
     };

--- a/src/lib/domains/preconf/service/BasedLinerService.ts
+++ b/src/lib/domains/preconf/service/BasedLinerService.ts
@@ -176,39 +176,30 @@ export class BasedLinerService {
    * @returns A promise that resolves to the average phase1 time in seconds.
    * @memberof BasedLinerService
    */
-  // TODO: Re-enable when API average is available
-  // static async fetchAveragePhase1(): Promise<number> {
-  //   if (!browser) return 0;
-  //   try {
-  //     const res = await fetch(`/api/basedliner/leaderboard/entry`, {
-  //       method: 'GET',
-  //       headers: { 'Content-Type': 'application/json' },
-  //     });
-
-  //     if (!res.ok) {
-  //       console.error('Error calling API:', res.status, res.statusText);
-  //       throw new Error(`API call failed: ${res.status} ${res.statusText}`);
-  //     }
-
-  //     const response = await res.json();
-  //     const firstEntry = response.entries?.[0];
-  //     if (firstEntry?.avg_phase1) {
-  //       return Number(firstEntry.avg_phase1) / 1000; // Convert ms to seconds
-  //     }
-  //     return 30;
-  //   } catch (error) {
-  //     console.error('Error fetching average phase1:', error);
-  //     return 30;
-  //   }
-  // }
-
-  /**
-   * Returns hardcoded 30 seconds for phase1 fallback.
-   * @returns 30 seconds
-   * @memberof BasedLinerService
-   */
   static async fetchAveragePhase1(): Promise<number> {
-    return 30;
+    if (!browser) return 0;
+    try {
+      const res = await fetch(`/api/basedliner/leaderboard/entry`, {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      if (!res.ok) {
+        console.error('Error calling API:', res.status, res.statusText);
+        throw new Error(`API call failed: ${res.status} ${res.statusText}`);
+      }
+
+      const response = await res.json();
+      const firstEntry = response.entries?.[0];
+
+      if (firstEntry?.avg_phase1) {
+        return Number(firstEntry.avg_phase1) / 1000; // Convert ms to seconds
+      }
+      return 42;
+    } catch (error) {
+      console.error('Error fetching average phase1:', error);
+      return 42;
+    }
   }
 }
 
@@ -221,6 +212,6 @@ function mapBasedlinerLeaderboardRow(row: BasedlinerLeaderboard): UnifiedLeaderb
     rank: row.rank,
     icon: '',
     data: [],
-    totalScore: Number(row.diff) || 0,
+    totalScore: Number(row.score) || 0,
   };
 }


### PR DESCRIPTION

**Scoring logic updates:**

* Updated all instances in `BasedLiners.svelte` to prioritize `entry.score` over `entry.diff` when calculating the score, ensuring consistency with the new leaderboard data structure. [[1]](diffhunk://#diff-c9122977e02601d49d3524012be0490b705e35d7a8173185a832e26ebfc24443L93-R93) [[2]](diffhunk://#diff-c9122977e02601d49d3524012be0490b705e35d7a8173185a832e26ebfc24443L127-R127) [[3]](diffhunk://#diff-c9122977e02601d49d3524012be0490b705e35d7a8173185a832e26ebfc24443L167-R167)
* Changed the mapping function in `BasedLinerService.ts` to use `row.score` for `totalScore` instead of `row.diff`.

**Average phase1 time handling:**

* Re-enabled and improved the API call in `fetchAveragePhase1` to fetch the average phase1 time from the backend, with a fallback value of 42 seconds if unavailable.