### PR TITLE
[TP-870] disable claim components

### DIFF
--- a/src/lib/domains/splashpage/components/index.svelte
+++ b/src/lib/domains/splashpage/components/index.svelte
@@ -5,7 +5,6 @@
   import FeaturedCampaigns from '$shared/components/FeaturedCampaigns/FeaturedCampaigns.svelte';
   import { classNames } from '$shared/utils/classNames';
 
-  import S4ClaimBanner from './Banner/S4ClaimBanner.svelte';
   import S5StartBanner from './Banner/S5StartBanner.svelte';
   import StatusBanner from './Banner/StatusBanner.svelte';
   import Factions from './Factions/Factions.svelte';
@@ -30,7 +29,6 @@
   const separator120pxClasses = classNames(separatorBaseClasses, 'h-[120px]');
 
   const slides: Slide[] = [
-    { component: S4ClaimBanner, url: 'https://trailblazers.taiko.xyz/profile' },
     { component: StatusBanner, url: 'https://taiko.mirror.xyz/SfIbIBBE1fDs2IjD4AxgK9r8IFi5LiqzsGpjb3sChIM' },
     {
       component: S5StartBanner,

--- a/src/lib/shared/components/Header/Header.svelte
+++ b/src/lib/shared/components/Header/Header.svelte
@@ -8,7 +8,7 @@
   import { classNames } from '$shared/utils/classNames';
 
   let isMenuOpen = false;
-  export let ribbonActive = true;
+  export let ribbonActive = false;
 
   const wrapperClasses = classNames(
     'w-[100vw]',


### PR DESCRIPTION

* Splash page banners:
  * Removed the import and usage of `S4ClaimBanner` from `index.svelte`, so the S4 claim banner will no longer be shown on the splash page. [[1]](diffhunk://#diff-3078b2559f011f8c535a532044e2626d3f91441eed47284c9a052e76b089694fL8) [[2]](diffhunk://#diff-3078b2559f011f8c535a532044e2626d3f91441eed47284c9a052e76b089694fL33)

* Header ribbon:
  * Changed the default value of the `ribbonActive` prop in `Header.svelte` from `true` to `false`, so the ribbon will be inactive unless explicitly enabled.