### PR TITLE
[chore] cleanup news and ribbon

### DIFF
--- a/src/lib/domains/profile/components/NewsCard/newsEntries.ts
+++ b/src/lib/domains/profile/components/NewsCard/newsEntries.ts
@@ -8,17 +8,6 @@ import type { NewsCardContent } from '$lib/domains/profile/types/NewsCardContent
 export const newsEntries: NewsCardContent[] = [
   {
     featured: true,
-    title: 'Claim your rewards',
-    subtitle: 'Season 4 rewards are waiting for you!',
-    text: 'If you participated in Season 4, make sure to claim your rewards before they expire.',
-    imgSrc: '/news/flame.svg',
-    cta: {
-      href: 'https://taiko.mirror.xyz/oqAfmnmsWpGsVC89GtIbPDreDv5c37JXx0m2_N5edB8',
-      external: true,
-    },
-  },
-  {
-    featured: false,
     title: 'Season 5 is here!',
     subtitle: 'Join now!',
     text: 'Blaze new trails, fuel Taiko’s momentum, and seize your chance for legendary rewards.',
@@ -26,13 +15,6 @@ export const newsEntries: NewsCardContent[] = [
     cta: {
       href: 'https://taiko.mirror.xyz/Bpu-YUgJXSoZRD-rGfsFVr-cb7QyI-6pn2GfJCuKNFc',
       external: true,
-    },
-  },
-  {
-    title: 'Liquidity Royale Season 5',
-    subtitle: 'Supercharge your liquidity and get rewarded for it',
-    cta: {
-      href: '/leaderboard/liquidity/4',
     },
   },
 ];

--- a/src/lib/shared/components/Header/Header.svelte
+++ b/src/lib/shared/components/Header/Header.svelte
@@ -8,7 +8,7 @@
   import { classNames } from '$shared/utils/classNames';
 
   let isMenuOpen = false;
-  export let ribbonActive = false;
+  export let ribbonActive;
 
   const wrapperClasses = classNames(
     'w-[100vw]',

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -71,7 +71,7 @@
     }
   });
 
-  let showRibbon = true;
+  let showRibbon = false;
 </script>
 
 {#if i18nReady}


### PR DESCRIPTION
**News Content Updates:**

* Removed the "Claim your rewards" and "Liquidity Royale Season 5" news entries from the `newsEntries` array in `newsEntries.ts`, leaving only the "Season 5 is here!" entry. [[1]](diffhunk://#diff-84f16130b908569ac37457f0b8e36a802a9b88b4f600d3e4ba85e7e6977af0d1L11-L21) [[2]](diffhunk://#diff-84f16130b908569ac37457f0b8e36a802a9b88b4f600d3e4ba85e7e6977af0d1L31-L37)

**Ribbon Display Logic:**

* Changed the default value of `showRibbon` from `true` to `false` in `+layout.svelte`, which means the ribbon will no longer be shown by default.
* Updated the `ribbonActive` prop in `Header.svelte` to no longer have a default value, allowing its state to be controlled externally.